### PR TITLE
Added clickable link via OSC standart

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Stats: https://pepy.tech/project/pystyle
   - Make boxes ✔️
   - Hide and Show Cursor ✔️
   - System Functions ✔️
+  - Clickable link ✔️
 
 <br>
 

--- a/pystyle/__init__.py
+++ b/pystyle/__init__.py
@@ -992,10 +992,10 @@ class Banner:
 class Link:
     """
     1 functions:
-        create_link()         |             make clickable link 
+        CreateLink()         |             make clickable link 
     """
 
-    def create_link(uri: str, label=None) -> str:
+    def CreateLink(uri: str, label=None) -> str:
         if label is None:
             label = uri
 

--- a/pystyle/__init__.py
+++ b/pystyle/__init__.py
@@ -989,6 +989,24 @@ class Banner:
         return _arrow
 
 
+class Link:
+    """
+    1 functions:
+        create_link()         |             make clickable link 
+    """
+
+    def create_link(uri: str, label=None) -> str:
+        if label is None:
+            label = uri
+
+        parameters = ""
+
+        # OSC 8 ; params ; URI ST <name> OSC 8 ;; ST
+        escape_mask = "\033]8;{};{}\033\\{}\033]8;;\033\\"
+
+        return escape_mask.format(parameters, uri, label)
+
+
 Box = Banner
 
 System.Init()


### PR DESCRIPTION
Example
```python
from pystyle import Link

print(Link.CreateLink('https://wikipedia.org', 'Wikipedia'))
```

More about OSC - https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda

Today almost all terminal support OSC.

Will be fine if you add my github on README.md, but this is not necessary ^-^.